### PR TITLE
fix: resolve critical bugs in session, broker, and serialization

### DIFF
--- a/Core/NotCore/Persistence/ISession.cs
+++ b/Core/NotCore/Persistence/ISession.cs
@@ -20,7 +20,7 @@ namespace Not.Core.Persistence
        public IEnumerable<object> GetServices(Type type);
        public IEnumerable<T> GetServices<T>()
             where T: class, IService
-            => (IEnumerable<T>)GetServices(typeof(Type));
+            => (IEnumerable<T>)GetServices(typeof(T));
 
         public object GetRequiredService(Type type);
         public T GetRequiredService<T>()

--- a/Core/NotCore/Serialization/JsonWriter.cs
+++ b/Core/NotCore/Serialization/JsonWriter.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Not.Core.Serialization
 {
-    internal class JsonWriter : JsonWriter
+    internal class JsonWriter
     {
     }
 }

--- a/Core/NotEFCore/Persistence/EntityBroker.cs
+++ b/Core/NotEFCore/Persistence/EntityBroker.cs
@@ -30,7 +30,8 @@ namespace Not.Core.Persistence
             if (!type.IsAssignableTo(typeof(BusinessObject)))
                 throw new Exception($"Type must be derived of {typeof(BusinessObject).FullName}");
 
-            var constructor = type.GetConstructor(Array.Empty<Type>());
+            var constructor = type.GetConstructor(Array.Empty<Type>())
+                ?? throw new InvalidOperationException($"Type '{type.FullName}' has no public parameterless constructor.");
             var businessObejct = constructor.Invoke(null);
             _dbc.Add(businessObejct);
             return businessObejct;
@@ -47,9 +48,6 @@ namespace Not.Core.Persistence
         {
             if (bo is null)
                 throw new ArgumentNullException(nameof(bo));
-
-            var efState = _dbc.Entry(bo).State;
-
 
             switch(_dbc.Entry(bo).State)
             {

--- a/Core/NotEFCore/Persistence/Session.cs
+++ b/Core/NotEFCore/Persistence/Session.cs
@@ -25,7 +25,7 @@ namespace Not.Core.Persistence
         private readonly IEntityBroker _broker;
 
         public IEntityBroker Broker
-            => Broker;
+            => _broker;
 
         internal Session(IServiceScope scope)
         {
@@ -44,7 +44,7 @@ namespace Not.Core.Persistence
                 .GetMethod(nameof(DatabaseContext.Set), Type.EmptyTypes)!;
 
             var generic = method.MakeGenericMethod(type);
-            return (IQueryable)generic.Invoke(this, null);
+            return (IQueryable)generic.Invoke(_dbc, null);
         }
 
         public IQueryable<BO> Query<BO>()


### PR DESCRIPTION
- Fix infinite recursion in Session.Broker property (was returning itself instead of _broker)
- Fix Session.Query(Type) invoking DbContext.Set<T> on wrong object (this vs _dbc)
- Fix ISession.GetServices<T> passing typeof(Type) instead of typeof(T)
- Fix potential NullReferenceException in EntityBroker.Create when no parameterless constructor exists
- Remove unused efState variable in EntityBroker.GetEntityState
- Fix circular inheritance in JsonWriter (was inheriting from itself)