### PR TITLE
feat: add unit tests with in-memory database

### DIFF
--- a/Core/NotCore/Serialization/JsonWriter.cs
+++ b/Core/NotCore/Serialization/JsonWriter.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Not.Core.Serialization
 {
-    internal class JsonWriter : JsonWriter
+    internal class JsonWriter
     {
     }
 }

--- a/NotFramework.sln
+++ b/NotFramework.sln
@@ -13,6 +13,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NotModel", "Core\NotModel\N
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NotPgSql", "Core\NotPgSql\NotPgSql.csproj", "{6A4670B6-47BB-FB5A-8865-2BF909EFFC9A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{A0B1C2D3-E4F5-6789-ABCD-EF0123456789}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NotFramework.Tests", "Tests\NotFramework.Tests\NotFramework.Tests.csproj", "{B1C2D3E4-F5A6-7890-BCDE-F12345678901}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +39,10 @@ Global
 		{6A4670B6-47BB-FB5A-8865-2BF909EFFC9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6A4670B6-47BB-FB5A-8865-2BF909EFFC9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6A4670B6-47BB-FB5A-8865-2BF909EFFC9A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -44,6 +52,7 @@ Global
 		{3E734279-BCCC-BAB3-F912-4A35E7A1BFA3} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{CBEECCAD-4B6C-F042-E5F1-2FFEDE0A435D} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{6A4670B6-47BB-FB5A-8865-2BF909EFFC9A} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{B1C2D3E4-F5A6-7890-BCDE-F12345678901} = {A0B1C2D3-E4F5-6789-ABCD-EF0123456789}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C7134CA4-9BBE-4C25-AC0F-E4AAA6AA8784}

--- a/Tests/NotFramework.Tests/ClassInfoTests.cs
+++ b/Tests/NotFramework.Tests/ClassInfoTests.cs
@@ -1,0 +1,148 @@
+using Not.Core.Model;
+using Not.Core.Model.Metadata;
+using Not.Core.Tests.Fixtures;
+using Xunit;
+
+namespace Not.Core.Tests;
+
+public class ClassInfoTests
+{
+    // ── Constructor validation ────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_ThrowsArgumentNullException_ForNullType()
+    {
+        Assert.Throws<ArgumentNullException>(() => new NullTypeClassInfo());
+    }
+
+    [Fact]
+    public void Constructor_ThrowsException_ForTypeNotDerivedFromBusinessObject()
+    {
+        Assert.Throws<Exception>(() => new NonBusinessObjectClassInfo());
+    }
+
+    // ── Basic properties ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Type_ReturnsEntityType()
+    {
+        Assert.Equal(typeof(Person), Person.ClassInfo.Type);
+        Assert.Equal(typeof(Employee), Employee.ClassInfo.Type);
+    }
+
+    [Fact]
+    public void ClassName_ReturnsSimpleTypeName()
+    {
+        Assert.Equal("Person", Person.ClassInfo.ClassName);
+        Assert.Equal("Employee", Employee.ClassInfo.ClassName);
+    }
+
+    // ── TableName ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TableName_WithNamespace_PrefixesLastNamespaceSegment()
+    {
+        // Person is in Not.Core.Tests.Fixtures → last segment = "Fixtures"
+        // Expected: "Fixtures" + "Person" = "FixturesPerson"
+        Assert.Equal("FixturesPerson", Person.ClassInfo.TableName);
+    }
+
+    [Fact]
+    public void TableName_WithNamespace_WorksForDerivedEntity()
+    {
+        Assert.Equal("FixturesEmployee", Employee.ClassInfo.TableName);
+    }
+
+    [Fact]
+    public void TableName_WithoutNamespace_IsJustClassName()
+    {
+        // GlobalNamespaceEntity has no namespace (null) → TableName = class name only
+        var ci = new GlobalNamespaceEntityClassInfo();
+        Assert.Equal(nameof(GlobalNamespaceEntity), ci.TableName);
+    }
+
+    // ── IsDerivation ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsDerivation_False_ForDirectBusinessObjectChild()
+    {
+        Assert.False(Person.ClassInfo.IsDerivation);
+    }
+
+    [Fact]
+    public void IsDerivation_True_ForEntityDerivedFromOtherEntity()
+    {
+        Assert.True(Employee.ClassInfo.IsDerivation);
+    }
+
+    // ── RootType ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void RootType_ForDirectChild_ReturnsSelf()
+    {
+        Assert.Equal(typeof(Person), Person.ClassInfo.RootType);
+    }
+
+    [Fact]
+    public void RootType_ForDerivedEntity_ReturnsDirectBusinessObjectChild()
+    {
+        // Employee → Person → BusinessObject; RootType should be Person
+        Assert.Equal(typeof(Person), Employee.ClassInfo.RootType);
+    }
+
+    // ── BaseType ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void BaseType_ForDirectChild_ReturnsSelf()
+    {
+        // Person directly extends BusinessObject → BaseType = Person itself
+        Assert.Equal(typeof(Person), Person.ClassInfo.BaseType);
+    }
+
+    [Fact]
+    public void BaseType_ForDerivedEntity_ReturnsImmediateParent()
+    {
+        Assert.Equal(typeof(Person), Employee.ClassInfo.BaseType);
+    }
+
+    // ── RootClassInfo ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void RootClassInfo_ForDirectChild_ReturnsSameInstance()
+    {
+        Assert.Same(Person.ClassInfo, Person.ClassInfo.RootClassInfo);
+    }
+
+    [Fact]
+    public void RootClassInfo_ForDerivedEntity_ReturnsRootEntityClassInfo()
+    {
+        // Employee's root is Person, so RootClassInfo should be Person.ClassInfo
+        Assert.Same(Person.ClassInfo, Employee.ClassInfo.RootClassInfo);
+    }
+
+    // ── Helpers for error-case testing ───────────────────────────────────────
+
+    // Passes null to the protected ClassInfo(Type) constructor
+    private sealed class NullTypeClassInfo : ClassInfo
+    {
+        public override int CID => 0;
+        public override string TableMappingStrategy => "TPH";
+        public NullTypeClassInfo() : base(null!) { }
+    }
+
+    // Passes a non-BusinessObject type
+    private sealed class NonBusinessObjectClassInfo : ClassInfo
+    {
+        public override int CID => 0;
+        public override string TableMappingStrategy => "TPH";
+        public NonBusinessObjectClassInfo() : base(typeof(string)) { }
+    }
+
+    // Wraps GlobalNamespaceEntity whose namespace is null (declared at global scope)
+    private sealed class GlobalNamespaceEntityClassInfo : ClassInfo
+    {
+        public override int CID => 0;
+        public override string TableMappingStrategy => "TPH";
+        public GlobalNamespaceEntityClassInfo() : base(typeof(GlobalNamespaceEntity)) { }
+    }
+}

--- a/Tests/NotFramework.Tests/EntityBrokerTests.cs
+++ b/Tests/NotFramework.Tests/EntityBrokerTests.cs
@@ -1,0 +1,226 @@
+using Not.Core.Model;
+using Not.Core.Persistence;
+using Not.Core.Tests.Fixtures;
+using Xunit;
+
+namespace Not.Core.Tests;
+
+public class EntityBrokerTests
+{
+    // Create<BO>() is a default interface method on IEntityBroker, so the variable
+    // must be typed as IEntityBroker (not the concrete EntityBroker class).
+    private static (TestContext ctx, IEntityBroker broker) CreateBroker(string? dbName = null)
+    {
+        var ctx = TestContext.CreateInMemory(dbName);
+        IEntityBroker broker = new EntityBroker(ctx);
+        return (ctx, broker);
+    }
+
+    // ── Constructor ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_ThrowsArgumentNullException_ForNullContext()
+    {
+        Assert.Throws<ArgumentNullException>(() => new EntityBroker(null!));
+    }
+
+    // ── Create ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Create_ReturnsInstanceOfRequestedType()
+    {
+        var (_, broker) = CreateBroker();
+
+        var person = broker.Create(typeof(Person));
+
+        Assert.NotNull(person);
+        Assert.IsType<Person>(person);
+    }
+
+    [Fact]
+    public void Create_Generic_ReturnsStronglyTypedInstance()
+    {
+        var (_, broker) = CreateBroker();
+
+        var person = broker.Create<Person>();
+
+        Assert.NotNull(person);
+        Assert.IsType<Person>(person);
+    }
+
+    [Fact]
+    public void Create_WorksForDerivedEntity()
+    {
+        var (_, broker) = CreateBroker();
+
+        var employee = broker.Create<Employee>();
+
+        Assert.NotNull(employee);
+        Assert.IsType<Employee>(employee);
+    }
+
+    [Fact]
+    public void Create_ThrowsArgumentNullException_ForNullType()
+    {
+        var (_, broker) = CreateBroker();
+
+        Assert.Throws<ArgumentNullException>(() => broker.Create(null!));
+    }
+
+    [Fact]
+    public void Create_ThrowsException_ForTypeNotDerivedFromBusinessObject()
+    {
+        var (_, broker) = CreateBroker();
+
+        Assert.Throws<Exception>(() => broker.Create(typeof(string)));
+    }
+
+    [Fact]
+    public void Create_TracksNewEntityAsAdded()
+    {
+        var (_, broker) = CreateBroker();
+
+        var person = broker.Create<Person>();
+
+        Assert.Equal(EntityState.Added, broker.GetEntityState(person));
+    }
+
+    // ── Delete ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Delete_ThrowsArgumentNullException_ForNullEntity()
+    {
+        var (_, broker) = CreateBroker();
+
+        Assert.Throws<ArgumentNullException>(() => broker.Delete(null!));
+    }
+
+    [Fact]
+    public void Delete_MarksEntityAsDeleted()
+    {
+        // Entity must be saved first; EF Core transitions an unsaved Added entity
+        // to Detached (not Deleted) when removed before SaveChanges.
+        var (ctx, broker) = CreateBroker();
+        var person = broker.Create<Person>();
+        person.Name = "ToDelete";
+        ctx.SaveChanges(); // state = Current
+
+        broker.Delete(person);
+
+        Assert.Equal(EntityState.Deleted, broker.GetEntityState(person));
+    }
+
+    [Fact]
+    public void Delete_UnsavedEntity_BecomesUntracked()
+    {
+        // EF Core specific: removing a never-saved (Added) entity detaches it.
+        var (_, broker) = CreateBroker();
+        var person = broker.Create<Person>();
+
+        broker.Delete(person);
+
+        // After removing an Added entity, it is Detached → GetEntityState throws
+        Assert.Throws<Exception>(() => broker.GetEntityState(person));
+    }
+
+    // ── GetEntityState ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetEntityState_ThrowsArgumentNullException_ForNullEntity()
+    {
+        var (_, broker) = CreateBroker();
+
+        Assert.Throws<ArgumentNullException>(() => broker.GetEntityState(null!));
+    }
+
+    [Fact]
+    public void GetEntityState_ThrowsException_ForUntrackedEntity()
+    {
+        var (_, broker) = CreateBroker();
+        var untracked = new Person { Name = "Ghost" };
+
+        Assert.Throws<Exception>(() => broker.GetEntityState(untracked));
+    }
+
+    [Fact]
+    public void GetEntityState_ReturnsAdded_ForNewlyCreatedEntity()
+    {
+        var (_, broker) = CreateBroker();
+        var person = broker.Create<Person>();
+
+        Assert.Equal(EntityState.Added, broker.GetEntityState(person));
+    }
+
+    [Fact]
+    public void GetEntityState_ReturnsCurrent_AfterCommit()
+    {
+        var (ctx, broker) = CreateBroker();
+        var person = broker.Create<Person>();
+        person.Name = "Alice";
+        ctx.SaveChanges();
+
+        Assert.Equal(EntityState.Current, broker.GetEntityState(person));
+    }
+
+    [Fact]
+    public void GetEntityState_ReturnsModified_AfterPropertyChange()
+    {
+        var (ctx, broker) = CreateBroker();
+        var person = broker.Create<Person>();
+        person.Name = "Alice";
+        ctx.SaveChanges();
+
+        person.Name = "Bob";
+
+        Assert.Equal(EntityState.Modified, broker.GetEntityState(person));
+    }
+
+    [Fact]
+    public void GetEntityState_ReturnsDeleted_AfterDelete()
+    {
+        var (ctx, broker) = CreateBroker();
+        var person = broker.Create<Person>();
+        person.Name = "Alice";
+        ctx.SaveChanges();
+
+        broker.Delete(person);
+
+        Assert.Equal(EntityState.Deleted, broker.GetEntityState(person));
+    }
+
+    // ── Multiple entities in same context ─────────────────────────────────────
+
+    [Fact]
+    public void Create_MultipleEntities_AreTrackedIndependently()
+    {
+        var (ctx, broker) = CreateBroker();
+
+        var p1 = broker.Create<Person>();
+        var p2 = broker.Create<Person>();
+        p1.Name = "Alice";
+        p2.Name = "Bob";
+        ctx.SaveChanges();
+
+        Assert.Equal(EntityState.Current, broker.GetEntityState(p1));
+        Assert.Equal(EntityState.Current, broker.GetEntityState(p2));
+    }
+
+    [Fact]
+    public void Commit_PersistsEntities_ToInMemoryStore()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var (ctx, broker) = CreateBroker(dbName);
+
+        var person = broker.Create<Person>();
+        person.Name = "Alice";
+        person.Age = 30;
+        ctx.SaveChanges();
+        ctx.Dispose();
+
+        // Open a second context on the same in-memory database
+        using var ctx2 = TestContext.CreateInMemory(dbName);
+        var loaded = ctx2.Set<Person>().Single();
+        Assert.Equal("Alice", loaded.Name);
+        Assert.Equal(30, loaded.Age);
+    }
+}

--- a/Tests/NotFramework.Tests/Fixtures/GlobalNamespaceEntity.cs
+++ b/Tests/NotFramework.Tests/Fixtures/GlobalNamespaceEntity.cs
@@ -1,0 +1,3 @@
+// No namespace declaration — type lives in the global namespace.
+// Used by ClassInfoTests to verify TableName behavior when Namespace is null.
+public class GlobalNamespaceEntity : Not.Core.Model.BusinessObject { }

--- a/Tests/NotFramework.Tests/Fixtures/TestContext.cs
+++ b/Tests/NotFramework.Tests/Fixtures/TestContext.cs
@@ -1,0 +1,70 @@
+using Microsoft.EntityFrameworkCore;
+using Not.Core.EF.Persistence.Model;
+using Not.Core.Model.Metadata;
+using Not.Core.Persistence;
+
+namespace Not.Core.Tests.Fixtures;
+
+/// <summary>
+/// Minimal DatabaseContext for EntityBroker and Session tests.
+/// Registers Person and Employee via explicit model configuration.
+/// </summary>
+public class TestContext : DatabaseContext
+{
+    public TestContext(DbContextOptions options) : base(options) { }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<Person>(e =>
+        {
+            e.HasKey(x => x.OID);
+            e.Property(x => x.Name);
+            e.Property(x => x.Age);
+        });
+
+        modelBuilder.Entity<Employee>(e =>
+        {
+            e.HasBaseType<Person>();
+            e.Property(x => x.Department);
+        });
+    }
+
+    public static TestContext CreateInMemory(string? dbName = null)
+    {
+        var options = new DbContextOptionsBuilder<TestContext>()
+            .UseInMemoryDatabase(dbName ?? Guid.NewGuid().ToString())
+            .Options;
+        return new TestContext(options);
+    }
+}
+
+/// <summary>
+/// ModelDefinition implementation for ModelDefinition tests.
+/// Uses TPH strategy for both Person and Employee.
+/// </summary>
+public class TestModelDefinition : ModelDefinition
+{
+    private static readonly Guid _guid = Guid.Parse("A1B2C3D4-E5F6-7890-ABCD-EF1234567890");
+
+    public override Guid Guid => _guid;
+    public override string Name => "TestModel";
+    public override string Version => "1.0.0";
+
+    public TestModelDefinition(DbContextOptions options) : base(options) { }
+
+    protected override IEnumerable<ClassInfo> GetClassInfos()
+    {
+        yield return Person.ClassInfo;
+        yield return Employee.ClassInfo;
+    }
+
+    public static TestModelDefinition CreateInMemory(string? dbName = null)
+    {
+        var options = new DbContextOptionsBuilder<TestModelDefinition>()
+            .UseInMemoryDatabase(dbName ?? Guid.NewGuid().ToString())
+            .Options;
+        return new TestModelDefinition(options);
+    }
+}

--- a/Tests/NotFramework.Tests/Fixtures/TestEntities.cs
+++ b/Tests/NotFramework.Tests/Fixtures/TestEntities.cs
@@ -1,0 +1,54 @@
+using Not.Core.Model;
+using Not.Core.Model.Metadata;
+using Not.Core.Model.Metadata.Property;
+using Not.Core.Service;
+
+namespace Not.Core.Tests.Fixtures;
+
+// --- Domain entities ---
+// PropertyInfo objects must be static fields on the entity class so that
+// CommonEntityTableMappingStrategy.BuildProperties() can find them via reflection.
+
+public class Person : BusinessObject
+{
+    public string Name { get; set; } = "";
+    public int Age { get; set; }
+
+    public static readonly PersonClassInfo ClassInfo = new();
+    public static readonly StringPropertyInfo<Person> NameInfo = new("Name");
+    public static readonly IntPropertyInfo<Person> AgeInfo = new("Age") { IsRequired = true };
+}
+
+public class PersonClassInfo : ClassInfo<Person>
+{
+    public override int CID => 100;
+    public override string TableMappingStrategy => "TPH";
+}
+
+// Employee is a derivation of Person (not a direct BusinessObject child)
+public class Employee : Person
+{
+    public string Department { get; set; } = "";
+
+    // 'new' hides the inherited Person.ClassInfo static field
+    public static new readonly EmployeeClassInfo ClassInfo = new();
+    public static readonly StringPropertyInfo<Employee> DepartmentInfo = new("Department");
+}
+
+public class EmployeeClassInfo : ClassInfo<Employee>
+{
+    public override int CID => 101;
+    public override string TableMappingStrategy => "TPH";
+}
+
+// --- Test service for Session service-resolution tests ---
+
+public interface IGreetingService : IService
+{
+    string Greet();
+}
+
+public class GreetingService : IGreetingService
+{
+    public string Greet() => "Hello from GreetingService";
+}

--- a/Tests/NotFramework.Tests/ModelDefinitionTests.cs
+++ b/Tests/NotFramework.Tests/ModelDefinitionTests.cs
@@ -1,0 +1,162 @@
+using Microsoft.EntityFrameworkCore;
+using Not.Core.Tests.Fixtures;
+using Xunit;
+
+namespace Not.Core.Tests;
+
+public class ModelDefinitionTests
+{
+    // ── ClassInfos aggregation ────────────────────────────────────────────────
+
+    [Fact]
+    public void ClassInfos_ContainsAllRegisteredClassInfos()
+    {
+        using var ctx = TestModelDefinition.CreateInMemory();
+
+        var classInfos = ctx.ClassInfos.ToList();
+
+        Assert.Contains(classInfos, ci => ci.Type == typeof(Person));
+        Assert.Contains(classInfos, ci => ci.Type == typeof(Employee));
+    }
+
+    [Fact]
+    public void ClassInfos_CountMatchesRegisteredEntities()
+    {
+        using var ctx = TestModelDefinition.CreateInMemory();
+
+        Assert.Equal(2, ctx.ClassInfos.Count());
+    }
+
+    // ── Include ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Include_AddsClassInfosFromDependency()
+    {
+        using var host = TestModelDefinition.CreateInMemory();
+        using var dep = new SecondTestModelDefinition(
+            new DbContextOptionsBuilder<SecondTestModelDefinition>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options);
+
+        host.Include(dep);
+
+        var types = host.ClassInfos.Select(ci => ci.Type).ToList();
+        Assert.Contains(typeof(Person), types);
+        Assert.Contains(typeof(Employee), types);
+        Assert.Contains(typeof(Address), types);
+    }
+
+    [Fact]
+    public void Include_ThrowsException_WhenSameModuleAddedTwice()
+    {
+        using var host = TestModelDefinition.CreateInMemory();
+        using var dep = new SecondTestModelDefinition(
+            new DbContextOptionsBuilder<SecondTestModelDefinition>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options);
+
+        host.Include(dep);
+
+        Assert.Throws<Exception>(() => host.Include(dep));
+    }
+
+    // ── Model building / EF Core integration ─────────────────────────────────
+
+    [Fact]
+    public void OnModelCreating_RegistersEntitiesForQuerying()
+    {
+        using var ctx = TestModelDefinition.CreateInMemory();
+        ctx.Database.EnsureCreated();
+
+        // If the model was built correctly we can query without exceptions
+        var people = ctx.Set<Person>().ToList();
+        var employees = ctx.Set<Employee>().ToList();
+
+        Assert.Empty(people);
+        Assert.Empty(employees);
+    }
+
+    [Fact]
+    public void OnModelCreating_ThrowsException_WhenClassInfoHasUnknownMappingStrategy()
+    {
+        var options = new DbContextOptionsBuilder<BadStrategyModelDefinition>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        using var ctx = new BadStrategyModelDefinition(options);
+
+        // EnsureCreated triggers OnModelCreating
+        Assert.Throws<Exception>(() => ctx.Database.EnsureCreated());
+    }
+
+    [Fact]
+    public void Metadata_Guid_Name_Version_AreExposed()
+    {
+        using var ctx = TestModelDefinition.CreateInMemory();
+
+        Assert.Equal(Guid.Parse("A1B2C3D4-E5F6-7890-ABCD-EF1234567890"), ctx.Guid);
+        Assert.Equal("TestModel", ctx.Name);
+        Assert.Equal("1.0.0", ctx.Version);
+    }
+}
+
+// ── Additional fixtures used only within ModelDefinitionTests ────────────────
+
+public class Address : Not.Core.Model.BusinessObject
+{
+    public string Street { get; set; } = "";
+
+    public static readonly AddressClassInfo ClassInfo = new();
+    public static readonly Not.Core.Model.Metadata.Property.StringPropertyInfo<Address> StreetInfo = new("Street");
+}
+
+public class AddressClassInfo : Not.Core.Model.Metadata.ClassInfo<Address>
+{
+    public override int CID => 200;
+    public override string TableMappingStrategy => "TPH";
+}
+
+/// <summary>Second model that owns Address, used for Include tests.</summary>
+public class SecondTestModelDefinition : Not.Core.EF.Persistence.Model.ModelDefinition
+{
+    private static readonly Guid _guid = Guid.Parse("B2C3D4E5-F6A7-8901-BCDE-F23456789012");
+
+    public override Guid Guid => _guid;
+    public override string Name => "SecondModel";
+    public override string Version => "1.0.0";
+
+    public SecondTestModelDefinition(DbContextOptions options) : base(options) { }
+
+    protected override IEnumerable<Not.Core.Model.Metadata.ClassInfo> GetClassInfos()
+    {
+        yield return Address.ClassInfo;
+    }
+}
+
+/// <summary>Model with a ClassInfo that returns an unknown mapping strategy.</summary>
+public class BadStrategyModelDefinition : Not.Core.EF.Persistence.Model.ModelDefinition
+{
+    private static readonly Guid _guid = Guid.Parse("C3D4E5F6-A7B8-9012-CDEF-123456789ABC");
+
+    public override Guid Guid => _guid;
+    public override string Name => "BadModel";
+    public override string Version => "1.0.0";
+
+    public BadStrategyModelDefinition(DbContextOptions options) : base(options) { }
+
+    protected override IEnumerable<Not.Core.Model.Metadata.ClassInfo> GetClassInfos()
+    {
+        yield return BadEntity.ClassInfo;
+    }
+}
+
+public class BadEntity : Not.Core.Model.BusinessObject
+{
+    public static readonly BadEntityClassInfo ClassInfo = new();
+}
+
+public class BadEntityClassInfo : Not.Core.Model.Metadata.ClassInfo<BadEntity>
+{
+    public override int CID => 999;
+    public override string TableMappingStrategy => "UNKNOWN_STRATEGY";
+}

--- a/Tests/NotFramework.Tests/NotFramework.Tests.csproj
+++ b/Tests/NotFramework.Tests/NotFramework.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Not.Core.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.22" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\NotCore\NotCore.csproj" />
+    <ProjectReference Include="..\..\Core\NotModel\NotModel.csproj" />
+    <ProjectReference Include="..\..\Core\NotEFCore\NotEFCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/NotFramework.Tests/PropertyInfoTests.cs
+++ b/Tests/NotFramework.Tests/PropertyInfoTests.cs
@@ -1,0 +1,101 @@
+using Not.Core.Model.Metadata.Property;
+using Not.Core.Tests.Fixtures;
+using Xunit;
+
+namespace Not.Core.Tests;
+
+public class PropertyInfoTests
+{
+    // ── PropertyName ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void PropertyName_ReturnsNameOfMappedProperty()
+    {
+        Assert.Equal("Name", Person.NameInfo.PropertyName);
+        Assert.Equal("Age", Person.AgeInfo.PropertyName);
+        Assert.Equal("Department", Employee.DepartmentInfo.PropertyName);
+    }
+
+    // ── PropertyType ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void PropertyType_ReturnsCorrectClrType()
+    {
+        Assert.Equal(typeof(string), Person.NameInfo.PropertyType);
+        Assert.Equal(typeof(int), Person.AgeInfo.PropertyType);
+        Assert.Equal(typeof(string), Employee.DepartmentInfo.PropertyType);
+    }
+
+    // ── ColumnName ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ColumnName_DefaultsToPropertyName()
+    {
+        // A freshly created PropertyInfo without explicit ColumnName assignment
+        var prop = new StringPropertyInfo<Person>("Name");
+        Assert.Equal("Name", prop.ColumnName);
+    }
+
+    [Fact]
+    public void ColumnName_CanBeOverridden()
+    {
+        var prop = new StringPropertyInfo<Person>("Name") { ColumnName = "person_name" };
+        Assert.Equal("person_name", prop.ColumnName);
+    }
+
+    [Fact]
+    public void ColumnName_OverrideDoesNotAffectPropertyName()
+    {
+        var prop = new StringPropertyInfo<Person>("Name") { ColumnName = "person_name" };
+        Assert.Equal("Name", prop.PropertyName);
+    }
+
+    // ── IsRequired ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsRequired_DefaultsFalse()
+    {
+        var prop = new StringPropertyInfo<Person>("Name");
+        Assert.False(prop.IsRequired);
+    }
+
+    [Fact]
+    public void IsRequired_CanBeSetToTrue()
+    {
+        var prop = new StringPropertyInfo<Person>("Name") { IsRequired = true };
+        Assert.True(prop.IsRequired);
+    }
+
+    // ── StringPropertyInfo ────────────────────────────────────────────────────
+
+    [Fact]
+    public void StringPropertyInfo_MaxLength_DefaultsZero()
+    {
+        var prop = new StringPropertyInfo<Person>("Name");
+        Assert.Equal(0, prop.MaxLength);
+    }
+
+    [Fact]
+    public void StringPropertyInfo_MaxLength_CanBeSet()
+    {
+        var prop = new StringPropertyInfo<Person>("Name") { MaxLength = 200 };
+        Assert.Equal(200, prop.MaxLength);
+    }
+
+    // ── Constructor validation ────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_ThrowsException_ForNonExistentProperty()
+    {
+        Assert.Throws<Exception>(() => new StringPropertyInfo<Person>("NonExistentProperty"));
+    }
+
+    [Fact]
+    public void Constructor_ThrowsException_ForWrongPropertyType()
+    {
+        // "Age" is an int property; using IntPropertyInfo<Person> is correct,
+        // but the constructor only validates existence, not type safety at runtime.
+        // Here we just confirm a missing name throws.
+        Assert.Throws<Exception>(() => new IntPropertyInfo<Person>("Missing"));
+    }
+}

--- a/Tests/NotFramework.Tests/SessionTests.cs
+++ b/Tests/NotFramework.Tests/SessionTests.cs
@@ -1,0 +1,176 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Not.Core.Persistence;
+using Not.Core.Tests.Fixtures;
+using Xunit;
+
+namespace Not.Core.Tests;
+
+public class SessionTests
+{
+    // ── DI / factory helpers ──────────────────────────────────────────────────
+
+    private static IServiceProvider BuildServiceProvider(string? dbName = null, bool addGreetingService = false)
+    {
+        var services = new ServiceCollection();
+
+        services.AddDbContext<TestContext>(opts =>
+            opts.UseInMemoryDatabase(dbName ?? Guid.NewGuid().ToString()));
+
+        // Session resolves DatabaseContext from scope; alias TestContext as DatabaseContext
+        services.AddScoped<DatabaseContext>(sp => sp.GetRequiredService<TestContext>());
+
+        services.AddSingleton<ISessionFactory, SessionFactory>();
+
+        if (addGreetingService)
+            services.AddScoped<IGreetingService, GreetingService>();
+
+        return services.BuildServiceProvider();
+    }
+
+    private static ISession CreateSession(IServiceProvider? sp = null)
+    {
+        sp ??= BuildServiceProvider();
+        return sp.GetRequiredService<ISessionFactory>().Create();
+    }
+
+    // ── Current session tracking ──────────────────────────────────────────────
+
+    [Fact]
+    public void Create_SetsCurrent_ToNewSession()
+    {
+        using var session = CreateSession();
+
+        Assert.NotNull(Session.Current);
+        Assert.Same(session, Session.Current);
+    }
+
+    [Fact]
+    public void Dispose_ClearsCurrent()
+    {
+        var session = CreateSession();
+
+        session.Dispose();
+
+        Assert.Null(Session.Current);
+    }
+
+    // ── Query<BO> ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void QueryGeneric_ReturnsEmptyQueryable_WhenNoDataExists()
+    {
+        using var session = CreateSession();
+
+        var result = session.Query<Person>().ToList();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void QueryGeneric_ReturnsPersistedEntities()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var sp = BuildServiceProvider(dbName);
+
+        // Persist via first session
+        using (var s1 = sp.GetRequiredService<ISessionFactory>().Create())
+        {
+            IEntityBroker broker = new EntityBroker(((Session)s1)._dbc);
+            var p = broker.Create<Person>();
+            p.Name = "Alice";
+            s1.Commit();
+        }
+
+        // Read via second session
+        using var s2 = sp.GetRequiredService<ISessionFactory>().Create();
+        var people = s2.Query<Person>().ToList();
+
+        Assert.Single(people);
+        Assert.Equal("Alice", people[0].Name);
+    }
+
+    [Fact]
+    public void Query_ByType_ThrowsException_ForNonBusinessObjectType()
+    {
+        using var session = CreateSession();
+
+        Assert.Throws<Exception>(() => session.Query(typeof(string)));
+    }
+
+    // ── Commit ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Commit_PersistsChanges()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var sp = BuildServiceProvider(dbName);
+
+        using (var s1 = sp.GetRequiredService<ISessionFactory>().Create())
+        {
+            IEntityBroker broker = new EntityBroker(((Session)s1)._dbc);
+            var p = broker.Create<Person>();
+            p.Name = "Bob";
+            s1.Commit();
+        }
+
+        // Verify via a raw context on the same database
+        using var ctx = TestContext.CreateInMemory(dbName);
+        Assert.Equal("Bob", ctx.Set<Person>().Single().Name);
+    }
+
+    // ── Service resolution ────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetService_ReturnsNull_WhenServiceNotRegistered()
+    {
+        using var session = CreateSession();
+
+        var result = session.GetService(typeof(IGreetingService));
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetRequiredService_ReturnsService_WhenRegistered()
+    {
+        var sp = BuildServiceProvider(addGreetingService: true);
+        using var session = sp.GetRequiredService<ISessionFactory>().Create();
+
+        var svc = session.GetRequiredService(typeof(IGreetingService)) as IGreetingService;
+
+        Assert.NotNull(svc);
+        Assert.Equal("Hello from GreetingService", svc.Greet());
+    }
+
+    [Fact]
+    public void GetRequiredService_Throws_WhenServiceNotRegistered()
+    {
+        using var session = CreateSession(addGreetingService: false);
+
+        Assert.ThrowsAny<Exception>(() => session.GetRequiredService(typeof(IGreetingService)));
+    }
+
+    private static ISession CreateSession(bool addGreetingService)
+        => BuildServiceProvider(addGreetingService: addGreetingService)
+            .GetRequiredService<ISessionFactory>()
+            .Create();
+
+    // ── GetServices ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetServices_ReturnsAllRegisteredImplementations()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<TestContext>(opts => opts.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+        services.AddScoped<DatabaseContext>(sp => sp.GetRequiredService<TestContext>());
+        services.AddSingleton<ISessionFactory, SessionFactory>();
+        services.AddScoped<IGreetingService, GreetingService>();
+        var sp = services.BuildServiceProvider();
+
+        using var session = sp.GetRequiredService<ISessionFactory>().Create();
+        var result = session.GetServices(typeof(IGreetingService)).ToList();
+
+        Assert.Single(result);
+    }
+}


### PR DESCRIPTION
- Add NotFramework.Tests project using xUnit and EF Core InMemory provider
- Tests cover ClassInfo metadata, PropertyInfo, EntityBroker CRUD/state tracking, Session lifecycle/queries/service-resolution, and ModelDefinition mapping
- Fix circular base-type bug in JsonWriter stub (blocked compilation)