### PR TITLE
fix: typos, add DecimalPropertyInfo with Precision/Scale

### DIFF
--- a/Core/NotCore/Localization/Culture.cs
+++ b/Core/NotCore/Localization/Culture.cs
@@ -27,7 +27,7 @@ namespace Not.Core.Localization
 
     }
 
-    public static class CultureSerice
+    public static class CultureService
     {
         public readonly static Culture Invariant = new("Invariant", "");
         public readonly static Culture German = new("Deutsch", "de");

--- a/Core/NotEFCore/Persistence/EntityBroker.cs
+++ b/Core/NotEFCore/Persistence/EntityBroker.cs
@@ -32,9 +32,9 @@ namespace Not.Core.Persistence
 
             var constructor = type.GetConstructor(Array.Empty<Type>())
                 ?? throw new InvalidOperationException($"Type '{type.FullName}' has no public parameterless constructor.");
-            var businessObejct = constructor.Invoke(null);
-            _dbc.Add(businessObejct);
-            return businessObejct;
+            var businessObject = constructor.Invoke(null);
+            _dbc.Add(businessObject);
+            return businessObject;
         }
 
         public void Delete(BusinessObject bo)

--- a/Core/NotEFCore/Persistence/Model/CommonEntityTableMappingStrategy.cs
+++ b/Core/NotEFCore/Persistence/Model/CommonEntityTableMappingStrategy.cs
@@ -32,6 +32,9 @@ namespace Not.Core.EF.Persistence.Model
                 var pBuilder = builder.Property(prop.PropertyType, prop.PropertyName)
                     .HasColumnName(prop.ColumnName)
                     .IsRequired(prop.IsRequired);
+
+                if (prop is IDecimalProperty decimalProp)
+                    pBuilder.HasPrecision(decimalProp.Precision, decimalProp.Scale);
             }
         }
     }

--- a/Core/NotModel/Metadata/Property/DecimalPropertyInfo.cs
+++ b/Core/NotModel/Metadata/Property/DecimalPropertyInfo.cs
@@ -1,0 +1,18 @@
+namespace Not.Core.Model.Metadata.Property
+{
+    public interface IDecimalProperty
+    {
+        int Precision { get; }
+        int Scale { get; }
+    }
+
+    public class DecimalPropertyInfo<BO> : PropertyInfo<BO, decimal>, IDecimalProperty
+        where BO : BusinessObject
+    {
+        public int Precision { get; set; } = 18;
+        public int Scale { get; set; } = 2;
+
+        public DecimalPropertyInfo(string propertyName)
+            : base(propertyName) { }
+    }
+}


### PR DESCRIPTION
- CultureSerice → CultureService
- businessObejct → businessObject in EntityBroker
- Add DecimalPropertyInfo<BO> with IDecimalProperty interface (Precision=18, Scale=2 defaults)
- CommonEntityTableMappingStrategy applies HasPrecision() for decimal properties