### PR TITLE
fix: address prio-1 review issues

### DIFF
--- a/Core/NotCore/Localization/Culture.cs
+++ b/Core/NotCore/Localization/Culture.cs
@@ -23,7 +23,7 @@ namespace Not.Core.Localization
             => Code.GetHashCode();
 
         public override bool Equals(object? obj)
-            => obj is string otherString && Code.Equals(otherString, StringComparison.InvariantCultureIgnoreCase);
+            => obj is Culture otherCulture && Code.Equals(otherCulture.Code, StringComparison.InvariantCultureIgnoreCase);
 
     }
 

--- a/Core/NotCore/Persistence/ISession.cs
+++ b/Core/NotCore/Persistence/ISession.cs
@@ -13,9 +13,9 @@ namespace Not.Core.Persistence
         public IEntityBroker Broker { get; }
 
         public object GetService(Type type);
-        public T GetService<T>()
-            where T : IService
-           => (T)GetService(typeof(T));
+        public T? GetService<T>()
+            where T : class
+           => GetService(typeof(T)) as T;
 
        public IEnumerable<object> GetServices(Type type);
        public IEnumerable<T> GetServices<T>()

--- a/Core/NotEFCore/Persistence/EntityBroker.cs
+++ b/Core/NotEFCore/Persistence/EntityBroker.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Windows.Markup;
 
 namespace Not.Core.Persistence
 {

--- a/Core/NotModel/Metadata/ClassInfo.cs
+++ b/Core/NotModel/Metadata/ClassInfo.cs
@@ -69,7 +69,7 @@ namespace Not.Core.Model.Metadata
             {
                 if(_baseClassInfo == null)
                 {
-                    _baseClassInfo = BaseType.GetField("ClassInfo", System.Reflection.BindingFlags.Static).GetValue(null) as ClassInfo;
+                    _baseClassInfo = BaseType.GetField("ClassInfo", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public).GetValue(null) as ClassInfo;
                 }
                 return _baseClassInfo;
             }


### PR DESCRIPTION
## Summary

- **EntityBroker**: Remove stray `using System.Windows.Markup` (WPF namespace, would break on Linux/macOS/CI)
- **ClassInfo.BaseClassInfo**: Add `BindingFlags.Public` to `GetField` call — without it reflection returns `null` and throws a `NullReferenceException` at runtime
- **Culture.Equals**: Compare against `Culture` instead of `string` — the previous check was always `false` for any `Culture` argument
- **ISession.GetService<T>**: Remove `IService` constraint so internal types like `DatabaseContext` can be retrieved via the generic overload; return type changed to `T?` with a safe `as` cast

## Test plan

- [ ] Build succeeds on Linux/CI (no `System.Windows.Markup` reference)
- [ ] `ClassInfo.BaseClassInfo` returns the correct value for derived entities
- [ ] `Culture.Equals` returns `true` when comparing two `Culture` instances with the same code
- [ ] `ISession.GetService<DatabaseContext>()` compiles and returns the instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)