### PR TITLE
feat: add AddNotSQLite DI registration (closes #10)

### DIFF
--- a/Core/NotSqlite/NotSqlite.csproj
+++ b/Core/NotSqlite/NotSqlite.csproj
@@ -11,4 +11,9 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\NotCore\NotCore.csproj" />
+    <ProjectReference Include="..\NotEFCore\NotEFCore.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Core/NotSqlite/ServiceCollectionExtensions.cs
+++ b/Core/NotSqlite/ServiceCollectionExtensions.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Not.Core.Persistence;
+
+namespace Not.Sqlite;
+
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers a SQLite-backed <typeparamref name="TContext"/> and the NotFramework
+    /// session infrastructure (<see cref="ISessionFactory"/>, <see cref="DatabaseContext"/>).
+    /// </summary>
+    public static IServiceCollection AddNotSQLite<TContext>(
+        this IServiceCollection services,
+        string connectionString)
+        where TContext : DatabaseContext
+    {
+        services.AddDbContext<TContext>(opts => opts.UseSqlite(connectionString));
+        services.AddScoped<DatabaseContext>(sp => sp.GetRequiredService<TContext>());
+        services.AddSingleton<ISessionFactory, SessionFactory>();
+        return services;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ServiceCollectionExtensions.AddNotSQLite<TContext>` to `NotSqlite` so consumers can register SQLite + session infrastructure with a single call
- Adds `ProjectReference` to `NotCore` and `NotEFCore` in `NotSqlite.csproj` (required by the new extension)

Closes #10.

## Test plan
- [ ] All 79 existing tests pass (`dotnet test`)
- [ ] `services.AddNotSQLite<MyContext>("Data Source=:memory:")` compiles and resolves `ISessionFactory` + `DatabaseContext` at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)